### PR TITLE
Fix one liner link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ubuntu
     wget https://raw.githubusercontent.com/gridcoin-community/Autonode/GridcoinAutoNode.sh ; sudo bash GridcoinAutoNode.sh
 Debian  
 
-    wget https://raw.githubusercontent.com/gridcoin-community/Autonode/GridcoinAutoNodeDebian.sh ; sudo bash GridcoinAutoNodeDebian.sh
+    wget https://raw.githubusercontent.com/gridcoin-community/Autonode/master/GridcoinAutoNodeDebian.sh ; sudo bash GridcoinAutoNodeDebian.sh
 
 Notes
 -----


### PR DESCRIPTION
One liner for Debian missing "master" from path.